### PR TITLE
Manage circular symlink reference

### DIFF
--- a/tests/test_repoinfo.py
+++ b/tests/test_repoinfo.py
@@ -732,7 +732,7 @@ class TestRepoInfo(unittest.TestCase):
         ric.ensure_branches_filled()
         self.assertEqual(ric.branches_filled, True)
         self.assertEqual(ric.branches_remote, [])
-        self.assertEqual(ric.branches_local, ['branch1', DEFAULT_BRANCH_NAME])
+        self.assertEqual(sorted(ric.branches_local), sorted(['branch1', DEFAULT_BRANCH_NAME]))
 
 
 

--- a/tests/test_repoinfo.py
+++ b/tests/test_repoinfo.py
@@ -743,8 +743,8 @@ class TestRepoInfo(unittest.TestCase):
         git_init_repo('.')
 
         git_dir = self.gitdir
-        os.chdir(git_dir)
-        (git_dir/'tmp_a/.git').mkdir(parents=True)
+        tmp_dir = git_dir / 'tmp_a'
+        (tmp_dir / '..git').mkdir(parents=True)
         mr = MultiRepo(str(git_dir))
         repo_list = mr.find_git_repos()
         self.assertEqual(set(repo_list), {'dir2'})
@@ -768,6 +768,7 @@ class TestRepoInfo(unittest.TestCase):
         self.assertEqual(added_repo[0].name, 'dir2')
         self.assertEqual(rm_repo,    [mr.repo_dict['removed']])
 
+        rmtree_failsafe(tmp_dir)
         rmtree_failsafe(self.dir2)
 
 


### PR DESCRIPTION
Thanks for the great tool :-) So useful when managing many repositories!

I faced some troubles when scanning one large dirtree with numbers of local git repositories and especially one (i.e. OpenWRT) which has some circular symlink references (like a symlink pointing to its parent folder). The application freezes since it enters an infinite loop when traversing the dir tree.

The PR aims at fixing this by using scandir instead of glob and detect symlink circular references.

Tested: Linux Ubuntu


